### PR TITLE
Fix non-transient crawler failures from praytime.sqlite

### DIFF
--- a/src/crawlers/CA/ON/mosque-aisha-naigara.ts
+++ b/src/crawlers/CA/ON/mosque-aisha-naigara.ts
@@ -73,21 +73,6 @@ const setLocationTimes = (
     throw new Error("missing Mosque Aisha record");
   }
 
-  const fajr = util.normalizeLooseClock(findPrayer(times, /^fajr$/i)?.time);
-  const zuhr = util.normalizeLooseClock(
-    findPrayer(times, /^dhuhr$|^duhur$|^zuhr$/i)?.time,
-  );
-  const asr = util.normalizeLooseClock(findPrayer(times, /^asr$/i)?.time);
-  const maghribPrayer = findPrayer(times, /^maghrib$/i);
-  const maghrib =
-    util.normalizeLooseClock(maghribPrayer?.start) ||
-    util.normalizeLooseClock(maghribPrayer?.time);
-  const isha = util.normalizeLooseClock(findPrayer(times, /^isha$/i)?.time);
-
-  if (!fajr || !zuhr || !asr || !maghrib || !isha) {
-    throw new Error(`missing iqama times for ${record.name}`);
-  }
-
   const jumaTimes = times
     .filter(
       (entry) =>
@@ -99,6 +84,22 @@ const setLocationTimes = (
     .map((entry) => util.normalizeLooseClock(entry.time))
     .filter((time): time is string => Boolean(time))
     .slice(0, 3);
+
+  const fajr = util.normalizeLooseClock(findPrayer(times, /^fajr$/i)?.time);
+  const zuhr =
+    util.normalizeLooseClock(
+      findPrayer(times, /^dhuhr$|^duhur$|^zuhr$/i)?.time,
+    ) || (util.isJumaToday(record) ? (jumaTimes[0] ?? "") : "");
+  const asr = util.normalizeLooseClock(findPrayer(times, /^asr$/i)?.time);
+  const maghribPrayer = findPrayer(times, /^maghrib$/i);
+  const maghrib =
+    util.normalizeLooseClock(maghribPrayer?.start) ||
+    util.normalizeLooseClock(maghribPrayer?.time);
+  const isha = util.normalizeLooseClock(findPrayer(times, /^isha$/i)?.time);
+
+  if (!fajr || !zuhr || !asr || !maghrib || !isha) {
+    throw new Error(`missing iqama times for ${record.name}`);
+  }
 
   util.setIqamaTimes(record, [fajr, zuhr, asr, maghrib, isha]);
   util.setJumaTimes(record, jumaTimes);

--- a/src/crawlers/US/CA/masjid-al-huda-union-city.ts
+++ b/src/crawlers/US/CA/masjid-al-huda-union-city.ts
@@ -1,5 +1,37 @@
+import Tesseract from "tesseract.js";
 import type { CrawlerModule } from "../../../types";
 import * as util from "../../../util";
+
+const JUMUAH_BANNER_URL =
+  "https://masjidal-huda.org/wp-content/uploads/2025/04/Jumuah-Schedule-Web-Banner.png";
+
+const loadBannerJumaTime = async (): Promise<string> => {
+  const { data } = await Tesseract.recognize(JUMUAH_BANNER_URL, "eng");
+  const rawTimes =
+    data.text.match(
+      /[^\s\d]?\s*:\s*\d{2}\s*[AP]M|\d{1,2}\s*:\s*\d{2}\s*[AP]M/gi,
+    ) ?? [];
+  const recognizedHours = Array.from(
+    new Set(
+      rawTimes
+        .map((value) => value.trim().match(/^\d/)?.[0])
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+  const fallbackHour =
+    recognizedHours.length === 1 ? (recognizedHours[0] ?? "") : "";
+  const normalizedTimes = rawTimes
+    .map((value) => {
+      const normalized = value.trim().replace(/^[^\d]+/, fallbackHour);
+      return util.extractTimeAmPm(normalized);
+    })
+    .filter((value): value is string => Boolean(value));
+  const firstTime = normalizedTimes[0];
+  if (!firstTime) {
+    throw new Error("failed to OCR Masjid Al-Huda Jumu'ah banner");
+  }
+  return firstTime;
+};
 
 const ids: CrawlerModule["ids"] = [
   {
@@ -18,6 +50,19 @@ const ids: CrawlerModule["ids"] = [
 const run = async () => {
   const $ = await util.load(ids[0].url);
   const prayerTimes = new Map<string, string>();
+  const jumaTimes = $("table tr")
+    .toArray()
+    .flatMap((row) => {
+      const prayerName = $(row).find(".prayerName").first().text().trim();
+      if (!/jum['’]?(u|o)?a?h/i.test(prayerName)) {
+        return [];
+      }
+
+      const publishedTime = util.normalizeLooseClock(
+        $(row).find("td").first().text(),
+      );
+      return publishedTime ? [publishedTime] : [];
+    });
 
   $("table tr").each((_, row) => {
     const prayerName = $(row).find(".prayerName").first().text().trim();
@@ -41,9 +86,11 @@ const run = async () => {
       "failed to parse Masjid Al-Huda iqama times",
     ),
   );
-  // The site currently publishes Jumu'ah on an image banner rather than
-  // machine-readable HTML, so keep a contract-safe placeholder.
-  util.setJumaTimes(ids[0], ["check website"]);
+  if (util.isJumaToday(ids[0])) {
+    const publishedJumaTimes =
+      jumaTimes.length > 0 ? jumaTimes : [await loadBannerJumaTime()];
+    util.setJumaTimes(ids[0], publishedJumaTimes.slice(0, 3));
+  }
 
   return ids;
 };

--- a/src/crawlers/US/CA/masjid-al-huda-union-city.ts
+++ b/src/crawlers/US/CA/masjid-al-huda-union-city.ts
@@ -17,17 +17,33 @@ const ids: CrawlerModule["ids"] = [
 ];
 const run = async () => {
   const $ = await util.load(ids[0].url);
+  const prayerTimes = new Map<string, string>();
 
-  const a = util.mapToText($, ".jamah");
+  $("table tr").each((_, row) => {
+    const prayerName = $(row).find(".prayerName").first().text().trim();
+    const prayerKey = util.getStandardPrayerKey(prayerName);
+    if (!prayerKey) {
+      return;
+    }
 
-  if (util.isJumaToday(ids[0])) {
-    const j = util.mapToText($, '.prayerName:contains("Jumuah") + td');
-    a.splice(1, 0, j[0] ?? "");
-    util.setIqamaTimes(ids[0], a);
-    util.setJumaTimes(ids[0], j);
-  } else {
-    util.setTimes(ids[0], a);
-  }
+    const iqamaTime = util.normalizeLooseClock(
+      $(row).find("td.jamah").first().text(),
+    );
+    if (iqamaTime) {
+      prayerTimes.set(prayerKey, iqamaTime);
+    }
+  });
+
+  util.setIqamaTimes(
+    ids[0],
+    util.requireStandardPrayerTimes(
+      prayerTimes,
+      "failed to parse Masjid Al-Huda iqama times",
+    ),
+  );
+  // The site currently publishes Jumu'ah on an image banner rather than
+  // machine-readable HTML, so keep a contract-safe placeholder.
+  util.setJumaTimes(ids[0], ["check website"]);
 
   return ids;
 };

--- a/src/crawlers/US/CA/sacramento-area-league-muslims-sacramento.ts
+++ b/src/crawlers/US/CA/sacramento-area-league-muslims-sacramento.ts
@@ -1,3 +1,7 @@
+import {
+  extractSunsetOffsetMinutes,
+  sunsetOffsetClock,
+} from "../../../suntime";
 import type { CrawlerModule } from "../../../types";
 import * as util from "../../../util";
 
@@ -18,17 +22,34 @@ const ids: CrawlerModule["ids"] = [
 const run = async () => {
   const $ = await util.load(ids[0].url);
 
-  const iqamaTimes = util
+  const rawIqamaTimes = util
     .mapToText($, ".nectar-list-item[data-text-align=right]")
     .slice(1);
-  if (iqamaTimes.length < 5) {
+  if (rawIqamaTimes.length < 5) {
     throw new Error("missing iqama times on SALAM Center homepage");
   }
+  const iqamaTimes = rawIqamaTimes.slice(0, 5).map((time, index) => {
+    if (index === 3) {
+      const fallbackOffsetMinutes = Number.parseInt(
+        time.match(/after\s*(\d+)\s*min/i)?.[1] ?? "",
+        10,
+      );
+      const sunsetOffsetMinutes =
+        extractSunsetOffsetMinutes(time) ||
+        (Number.isFinite(fallbackOffsetMinutes) ? fallbackOffsetMinutes : null);
+      if (sunsetOffsetMinutes !== null) {
+        return sunsetOffsetClock(ids[0], sunsetOffsetMinutes);
+      }
+    }
+
+    return util.normalizeLooseClock(time);
+  });
 
   const jumaTimesFromHeadings = util
     .mapToText($, "h3")
     .filter((text) => text.toLowerCase().includes("jumu"))
-    .flatMap((text) => util.matchTimeAmPmG(text) ?? []);
+    .map((text) => util.extractTimeAmPm(text))
+    .filter((time): time is string => Boolean(time));
 
   const jumaTimesFromEvents = $(".mec-event-title")
     .toArray()
@@ -44,14 +65,14 @@ const run = async () => {
       return startTime ? [startTime] : [];
     });
 
-  const jumaTimes = [
-    ...new Set([...jumaTimesFromHeadings, ...jumaTimesFromEvents]),
-  ];
+  const jumaTimes = Array.from(
+    new Set([...jumaTimesFromHeadings, ...jumaTimesFromEvents]),
+  );
   if (jumaTimes.length === 0) {
     throw new Error("missing Juma times on SALAM Center homepage");
   }
 
-  util.setIqamaTimes(ids[0], iqamaTimes.slice(0, 5));
+  util.setIqamaTimes(ids[0], iqamaTimes);
   util.setJumaTimes(ids[0], jumaTimes.slice(0, 3));
 
   return ids;

--- a/src/crawlers/US/MN/al-amaan-center-minnetonka.ts
+++ b/src/crawlers/US/MN/al-amaan-center-minnetonka.ts
@@ -1,5 +1,45 @@
-import { createMohidWidgetRun } from "../../../mohid";
+import { loadPdfText } from "../../../pdftext";
 import type { CrawlerModule } from "../../../types";
+import * as util from "../../../util";
+
+const PRAYER_TIMES_PDF_URL =
+  "https://www.alamaan.org/_files/ugd/db7ef5_409d76110e04490092e27bf19cfbbab9.pdf";
+
+const findPrayerTimesPdfLine = (
+  text: string,
+  record: CrawlerModule["ids"][number] | undefined,
+): string | undefined => {
+  if (!record) {
+    return undefined;
+  }
+
+  const month = util.strftime("%b", record);
+  const day = String(Number.parseInt(util.strftime("%d", record), 10));
+  const datePattern = new RegExp(`^${day}-${month}\\b`, "i");
+
+  return text
+    .split(/\r?\n/)
+    .map(util.normalizeSpace)
+    .find((line) => datePattern.test(line));
+};
+
+const prayerTimesFromPdfLine = (line: string): string[] => {
+  const times = line.match(/\b\d{1,2}:\d{2}\b/g) ?? [];
+  if (times.length < 9) {
+    throw new Error("unexpected Al-Amaan prayer times row format");
+  }
+
+  const fajr = util.normalize24HourClock(times[1] ?? "");
+  const zuhr = util.normalize24HourClock(times[4] ?? "");
+  const asr = util.normalize24HourClock(times[6] ?? "");
+  const maghrib = util.normalize24HourClock(times[7] ?? "");
+  const isha = util.normalize24HourClock(times[8] ?? "");
+  if (!fajr || !zuhr || !asr || !maghrib || !isha) {
+    throw new Error("missing Al-Amaan daily prayer times in PDF");
+  }
+
+  return [fajr, zuhr, asr, maghrib, isha];
+};
 
 const ids: CrawlerModule["ids"] = [
   {
@@ -19,5 +59,27 @@ const ids: CrawlerModule["ids"] = [
 export const crawler: CrawlerModule = {
   name: "US/MN/al-amaan-center-minnetonka",
   ids,
-  run: createMohidWidgetRun(ids, "https://us.mohid.co/mn/minneapolis/alamaan"),
+  run: async () => {
+    const prayerTimesPdfText = await loadPdfText(PRAYER_TIMES_PDF_URL);
+    const todayLine = findPrayerTimesPdfLine(prayerTimesPdfText, ids[0]);
+    if (!todayLine) {
+      throw new Error("missing Al-Amaan prayer times PDF row");
+    }
+
+    const jumaLine = prayerTimesPdfText
+      .split(/\r?\n/)
+      .map(util.normalizeSpace)
+      .find((line) => /Friday Khutbas:/i.test(line));
+    const jumaTimes = [...(util.matchTimeAmPmG(jumaLine) ?? [])]
+      .map(util.extractTimeAmPm)
+      .filter((value): value is string => Boolean(value));
+    if (jumaTimes.length === 0) {
+      throw new Error("missing Al-Amaan Friday khutbah times in PDF");
+    }
+
+    util.setIqamaTimes(ids[0], prayerTimesFromPdfLine(todayLine));
+    util.setJumaTimes(ids[0], jumaTimes);
+
+    return ids;
+  },
 };

--- a/src/crawlers/US/NY/cheektowaga-islamic-cultural-center-cheektowaga.ts
+++ b/src/crawlers/US/NY/cheektowaga-islamic-cultural-center-cheektowaga.ts
@@ -1,6 +1,5 @@
-import { createPuppeteerRun } from "../../../ppt";
+import { createMosquePrayerTimesRun } from "../../../ppt";
 import type { CrawlerModule } from "../../../types";
-import * as util from "../../../util";
 
 const crawlerPuppeteer = true;
 const ids: CrawlerModule["ids"] = [
@@ -20,15 +19,6 @@ const ids: CrawlerModule["ids"] = [
 export const crawler: CrawlerModule = {
   name: "US/NY/cheektowaga-islamic-cultural-center-cheektowaga",
   ids,
-  run: createPuppeteerRun(ids, async (page) => {
-    await page.goto(ids[0].url ?? "", { waitUntil: "networkidle0" });
-
-    const times = await util.pptMapToText(
-      page,
-      ".timetable-verticle .brrt .tdy",
-    );
-    times.splice(1, 1);
-    util.setTimes(ids[0], times);
-  }),
+  run: createMosquePrayerTimesRun(ids),
   puppeteer: crawlerPuppeteer,
 };

--- a/src/crawlers/US/NY/isnf-masjid-an-noor-amherst-getzville.ts
+++ b/src/crawlers/US/NY/isnf-masjid-an-noor-amherst-getzville.ts
@@ -8,13 +8,16 @@ const AMHERST_RAMADAN_PDF_URL =
 const BUFFALO_RAMADAN_PDF_URL =
   "https://isnfwny.org/s/ISNF-Masjid-At-Taqwa-2026-Ramadan-Schedule.pdf";
 
-const ramadanIqamaTimes = (line: string): string[] => {
+const ramadanIqamaTimes = (line: string): string[] | null => {
   const times =
     [...(line.match(/\d{1,2}:\d{2}\s*[AP]M/gi) ?? [])]
       .map(util.extractTimeAmPm)
       .filter((value): value is string => Boolean(value)) ?? [];
 
   if (times.length < 8) {
+    if (/eid/i.test(line)) {
+      return null;
+    }
     throw new Error("unexpected ISNF Ramadan row format");
   }
 
@@ -80,13 +83,21 @@ const run = async () => {
   const amherstPdfText = await loadPdfText(AMHERST_RAMADAN_PDF_URL);
   const amherstRow = findPdfDateLine(amherstPdfText, amherst);
   if (amherstRow) {
-    util.setIqamaTimes(amherst, ramadanIqamaTimes(amherstRow));
+    const amherstTimes = ramadanIqamaTimes(amherstRow);
+    if (amherstTimes) {
+      util.setIqamaTimes(amherst, amherstTimes);
+    }
   }
 
   const buffaloPdfText = await loadPdfText(BUFFALO_RAMADAN_PDF_URL);
   const buffaloRow = findPdfDateLine(buffaloPdfText, buffalo);
   if (buffaloRow) {
-    util.setIqamaTimes(buffalo, ramadanIqamaTimes(buffaloRow));
+    const buffaloTimes = ramadanIqamaTimes(buffaloRow);
+    if (buffaloTimes) {
+      util.setIqamaTimes(buffalo, buffaloTimes);
+    } else if (/eid/i.test(buffaloRow)) {
+      util.setCheckWebsiteTimes(buffalo);
+    }
   }
 
   return ids;

--- a/src/crawlers/US/NY/isnf-masjid-an-noor-amherst-getzville.ts
+++ b/src/crawlers/US/NY/isnf-masjid-an-noor-amherst-getzville.ts
@@ -86,6 +86,10 @@ const run = async () => {
     const amherstTimes = ramadanIqamaTimes(amherstRow);
     if (amherstTimes) {
       util.setIqamaTimes(amherst, amherstTimes);
+    } else {
+      throw new Error(
+        "ISNF Amherst Ramadan calendar lists Eid instead of iqama times",
+      );
     }
   }
 
@@ -95,8 +99,10 @@ const run = async () => {
     const buffaloTimes = ramadanIqamaTimes(buffaloRow);
     if (buffaloTimes) {
       util.setIqamaTimes(buffalo, buffaloTimes);
-    } else if (/eid/i.test(buffaloRow)) {
-      util.setCheckWebsiteTimes(buffalo);
+    } else {
+      throw new Error(
+        "ISNF Buffalo Ramadan calendar lists Eid instead of iqama times",
+      );
     }
   }
 

--- a/src/crawlers/US/NY/masjid-al-salam-msjd-lslm-buffalo.ts
+++ b/src/crawlers/US/NY/masjid-al-salam-msjd-lslm-buffalo.ts
@@ -1,6 +1,5 @@
-import { createPuppeteerRun } from "../../../ppt";
+import { createMosquePrayerTimesRun } from "../../../ppt";
 import type { CrawlerModule } from "../../../types";
-import * as util from "../../../util";
 
 const ids: CrawlerModule["ids"] = [
   {
@@ -19,15 +18,6 @@ const ids: CrawlerModule["ids"] = [
 export const crawler: CrawlerModule = {
   name: "US/NY/masjid-al-salam-msjd-lslm-buffalo",
   ids,
-  run: createPuppeteerRun(ids, async (page) => {
-    await page.goto(ids[0].url, { waitUntil: "networkidle0" });
-
-    const times = await util.pptMapToText(
-      page,
-      ".timetable-verticle .brrt .tdy",
-    );
-    times.splice(1, 1); // remove shuruq
-    util.setTimes(ids[0], times);
-  }),
+  run: createMosquePrayerTimesRun(ids),
   puppeteer: true,
 };

--- a/src/crawlers/US/TN/salahadeen-center-nashville.ts
+++ b/src/crawlers/US/TN/salahadeen-center-nashville.ts
@@ -1,7 +1,28 @@
-import { createMadinaAppsRun } from "../../../madinaapps";
 import type { CrawlerModule } from "../../../types";
+import * as util from "../../../util";
 
 const MADINAAPPS_CLIENT_ID = "53";
+const MADINAAPPS_PRAYER_TIMES_URL = `https://services.madinaapps.com/kiosk-rest/clients/${MADINAAPPS_CLIENT_ID}/prayerTimes`;
+
+type MadinaAppsPrayerDay = {
+  asr?: { iqamahTime?: unknown } | null;
+  dhuhr?: { iqamahTime?: unknown } | null;
+  fajr?: { iqamahTime?: unknown } | null;
+  isha?: { iqamahTime?: unknown } | null;
+  juma?: {
+    juma1KhutbaTime?: unknown;
+    juma2KhutbaTime?: unknown;
+    juma3KhutbaTime?: unknown;
+  } | null;
+  jumaTimes?: Array<{
+    khutbaTime?: unknown;
+  }> | null;
+  maghrib?: { iqamahTime?: unknown } | null;
+};
+
+type MadinaAppsPrayerResponse = {
+  prayerTimes?: MadinaAppsPrayerDay[] | null;
+};
 
 const ids: CrawlerModule["ids"] = [
   {
@@ -20,5 +41,60 @@ const ids: CrawlerModule["ids"] = [
 export const crawler: CrawlerModule = {
   name: "US/TN/salahadeen-center-nashville",
   ids,
-  run: createMadinaAppsRun(ids, MADINAAPPS_CLIENT_ID),
+  run: async () => {
+    const response = await util.loadJson<MadinaAppsPrayerResponse>(
+      MADINAAPPS_PRAYER_TIMES_URL,
+    );
+    const today = Array.isArray(response.prayerTimes)
+      ? response.prayerTimes[0]
+      : undefined;
+    if (!today) {
+      throw new Error("missing MadinaApps prayer times payload");
+    }
+
+    const dailyIqamaTimes = [
+      util.normalizeLooseClock(today.fajr?.iqamahTime),
+      util.normalizeLooseClock(today.dhuhr?.iqamahTime),
+      util.normalizeLooseClock(today.asr?.iqamahTime),
+      util.normalizeLooseClock(today.maghrib?.iqamahTime),
+      util.normalizeLooseClock(today.isha?.iqamahTime),
+    ];
+    const hasAnyDailyIqama = dailyIqamaTimes.some((value) => value.length > 0);
+    const hasAllDailyIqama = dailyIqamaTimes.every((value) => value.length > 0);
+    if (hasAnyDailyIqama && !hasAllDailyIqama) {
+      throw new Error("partial MadinaApps iqamah payload");
+    }
+
+    const jumaTimes = (
+      Array.isArray(today.jumaTimes) && today.jumaTimes.length > 0
+        ? today.jumaTimes.map((entry) =>
+            util.normalizeLooseClock(entry.khutbaTime),
+          )
+        : [
+            util.normalizeLooseClock(today.juma?.juma1KhutbaTime),
+            util.normalizeLooseClock(today.juma?.juma2KhutbaTime),
+            util.normalizeLooseClock(today.juma?.juma3KhutbaTime),
+          ]
+    ).filter((value): value is string => Boolean(value));
+    if (jumaTimes.length === 0) {
+      throw new Error("missing juma times payload");
+    }
+
+    if (hasAllDailyIqama) {
+      util.setIqamaTimes(ids[0], dailyIqamaTimes);
+    } else {
+      // The live MadinaApps payload currently omits all five daily iqamah
+      // fields, so fail closed while preserving the published Jumu'ah slots.
+      util.setIqamaTimes(ids[0], [
+        "check website",
+        "check website",
+        "check website",
+        "check website",
+        "check website",
+      ]);
+    }
+    util.setJumaTimes(ids[0], jumaTimes);
+
+    return ids;
+  },
 };

--- a/src/crawlers/US/TN/salahadeen-center-nashville.ts
+++ b/src/crawlers/US/TN/salahadeen-center-nashville.ts
@@ -61,8 +61,12 @@ export const crawler: CrawlerModule = {
     ];
     const hasAnyDailyIqama = dailyIqamaTimes.some((value) => value.length > 0);
     const hasAllDailyIqama = dailyIqamaTimes.every((value) => value.length > 0);
-    if (hasAnyDailyIqama && !hasAllDailyIqama) {
-      throw new Error("partial MadinaApps iqamah payload");
+    if (!hasAllDailyIqama) {
+      throw new Error(
+        hasAnyDailyIqama
+          ? "partial MadinaApps iqamah payload"
+          : "missing MadinaApps iqamah payload",
+      );
     }
 
     const jumaTimes = (
@@ -80,19 +84,7 @@ export const crawler: CrawlerModule = {
       throw new Error("missing juma times payload");
     }
 
-    if (hasAllDailyIqama) {
-      util.setIqamaTimes(ids[0], dailyIqamaTimes);
-    } else {
-      // The live MadinaApps payload currently omits all five daily iqamah
-      // fields, so fail closed while preserving the published Jumu'ah slots.
-      util.setIqamaTimes(ids[0], [
-        "check website",
-        "check website",
-        "check website",
-        "check website",
-        "check website",
-      ]);
-    }
+    util.setIqamaTimes(ids[0], dailyIqamaTimes);
     util.setJumaTimes(ids[0], jumaTimes);
 
     return ids;

--- a/src/crawlers/US/TX/barakat-ul-quran-irving.ts
+++ b/src/crawlers/US/TX/barakat-ul-quran-irving.ts
@@ -16,23 +16,6 @@ type BarkaatJummahTime = {
   iqama_time3?: string | null;
 };
 
-const normalizeApiClock = (value: string | null | undefined): string => {
-  const match = value?.trim().match(/^(\d{1,2}):(\d{2})(?::\d{2})?$/);
-  if (!match?.[1] || !match[2]) {
-    return "";
-  }
-
-  const hours24 = Number.parseInt(match[1], 10);
-  const minutes = match[2];
-  if (!Number.isFinite(hours24)) {
-    return "";
-  }
-
-  const suffix = hours24 >= 12 ? "PM" : "AM";
-  const hours12 = ((hours24 + 11) % 12) + 1;
-  return `${hours12}:${minutes} ${suffix}`;
-};
-
 const parseInlineJson = <T>(html: string, label: string): T => {
   const match = html.match(
     new RegExp(
@@ -77,13 +60,13 @@ const run = async () => {
   const maghribIqama =
     prayerTimes.magrib_i && prayerTimes.magrib_i === prayerTimes.sunrise
       ? "sunset"
-      : normalizeApiClock(prayerTimes.magrib_i);
+      : util.normalize24HourClock(prayerTimes.magrib_i);
   const iqamaTimes = [
-    normalizeApiClock(prayerTimes.fajr_i),
-    normalizeApiClock(prayerTimes.dahur_i),
-    normalizeApiClock(prayerTimes.asar_i),
+    util.normalize24HourClock(prayerTimes.fajr_i),
+    util.normalize24HourClock(prayerTimes.dahur_i),
+    util.normalize24HourClock(prayerTimes.asar_i),
     maghribIqama,
-    normalizeApiClock(prayerTimes.isha_i),
+    util.normalize24HourClock(prayerTimes.isha_i),
   ];
 
   if (iqamaTimes.some((value) => value.length === 0)) {
@@ -94,9 +77,9 @@ const run = async () => {
   util.setJumaTimes(
     ids[0],
     [
-      normalizeApiClock(jummahTimes.iqama_time1),
-      normalizeApiClock(jummahTimes.iqama_time2),
-      normalizeApiClock(jummahTimes.iqama_time3),
+      util.normalize24HourClock(jummahTimes.iqama_time1),
+      util.normalize24HourClock(jummahTimes.iqama_time2),
+      util.normalize24HourClock(jummahTimes.iqama_time3),
     ].filter((value): value is string => value.length > 0),
   );
 

--- a/src/crawlers/US/UT/islamic-society-of-greater-salt-lake.ts
+++ b/src/crawlers/US/UT/islamic-society-of-greater-salt-lake.ts
@@ -126,9 +126,9 @@ const run = async () => {
     trailingPattern: "\\w+\\b",
   });
   if (!row && hasCurrentEidNotice(pdfText, first)) {
-    util.setCheckWebsiteTimes(first);
-    util.setCheckWebsiteTimes(second);
-    return ids;
+    throw new Error(
+      "ISGSL Ramadan calendar lists Eid instead of current iqama times",
+    );
   }
   const currentIqamaTimes = row ? ramadanIqamaTimes(row) : null;
 

--- a/src/crawlers/US/UT/islamic-society-of-greater-salt-lake.ts
+++ b/src/crawlers/US/UT/islamic-society-of-greater-salt-lake.ts
@@ -20,6 +20,24 @@ const ramadanIqamaTimes = (line: string): string[] => {
   ];
 };
 
+const hasCurrentEidNotice = (
+  text: string,
+  record: CrawlerModule["ids"][number] | undefined,
+): boolean => {
+  if (!record) {
+    return false;
+  }
+
+  const month = util.strftime("%B", record);
+  const day = String(Number.parseInt(util.strftime("%d", record), 10));
+  const normalized = util.normalizeSpace(text);
+
+  return (
+    /eid/i.test(normalized) &&
+    new RegExp(`\\b${month}\\s+${day}\\b`, "i").test(normalized)
+  );
+};
+
 const ids: CrawlerModule["ids"] = [
   {
     uuid4: "9fe30cc6-6683-46c3-808e-71646b1e124d",
@@ -107,6 +125,11 @@ const run = async () => {
     anchored: true,
     trailingPattern: "\\w+\\b",
   });
+  if (!row && hasCurrentEidNotice(pdfText, first)) {
+    util.setCheckWebsiteTimes(first);
+    util.setCheckWebsiteTimes(second);
+    return ids;
+  }
   const currentIqamaTimes = row ? ramadanIqamaTimes(row) : null;
 
   // The live Google sheet is stale during Ramadan; the published PDF calendar

--- a/src/crawlers/US/VA/adams-center.ts
+++ b/src/crawlers/US/VA/adams-center.ts
@@ -235,7 +235,6 @@ const normalizeSpace = (text: string): string =>
   text.replace(/[’]/g, "'").replace(/\s+/g, " ").trim();
 
 const uniqueTimes = (times: string[]): string[] => Array.from(new Set(times));
-const adamsCheckWebsiteTimes = (): string[] => ["check website"];
 
 const settlePromise = async <T>(
   promise: Promise<T>,
@@ -298,17 +297,6 @@ const extractAdamsJumaTimes = (
   }
   return times;
 };
-
-const fallbackAdamsJumaTimes = (): AdamsJumaTimes => ({
-  ashburn: adamsCheckWebsiteTimes(),
-  fairfax: adamsCheckWebsiteTimes(),
-  gainesville: adamsCheckWebsiteTimes(),
-  leesburg: adamsCheckWebsiteTimes(),
-  leesburgSatellite: adamsCheckWebsiteTimes(),
-  reston: adamsCheckWebsiteTimes(),
-  sterling: adamsCheckWebsiteTimes(),
-  sully: adamsCheckWebsiteTimes(),
-});
 
 const extractAdamsJumaTimesFromSources = (
   texts: string[],
@@ -384,15 +372,6 @@ const loadAdamsJumaTimes = async (): Promise<AdamsJumaTimes> => {
   const parsed = extractAdamsJumaTimesFromSources(sourceTexts);
   if (parsed) {
     return parsed;
-  }
-
-  if (
-    typeof renderedContent === "string" &&
-    /wp-content\/uploads\/\d{4}\/\d{2}\/[^"' >]*(jummah|jumuah|jum['’]?ah)[^"' >]*\.(png|jpe?g)/i.test(
-      renderedContent,
-    )
-  ) {
-    return fallbackAdamsJumaTimes();
   }
 
   throw new Error("missing ADAMS Jumu'ah schedule");

--- a/src/crawlers/US/VA/adams-center.ts
+++ b/src/crawlers/US/VA/adams-center.ts
@@ -1,3 +1,4 @@
+import * as cheerio from "cheerio";
 import puppeteer from "puppeteer";
 import type { CrawlerModule } from "../../../types";
 import * as util from "../../../util";
@@ -167,6 +168,8 @@ const ids: CrawlerModule["ids"] = [
 const ADAMS_IQAMA_WIDGET_URL =
   "https://www-adamscenter-org.filesusr.com/html/a49bbb_018741b5b83d5042e9cf79cb18576f7b.html";
 const ADAMS_JUMUAH_URL = "https://www.adamscenter.org/jumuah/";
+const ADAMS_JUMUAH_API_URL =
+  "https://www.adamscenter.org/wp-json/wp/v2/pages?slug=jumuah&_fields=content.rendered";
 const MCLEAN_PRAYER_URL = "https://themasjidapp.org/40/prayers";
 const ADAMS_JUMUAH_LABELS = [
   "Sterling Jumu'ah",
@@ -201,6 +204,23 @@ type AdamsMasjidAppPayload = {
   };
 };
 
+type AdamsWordPressPage = {
+  content?: {
+    rendered?: unknown;
+  };
+};
+
+type AdamsJumaTimes = {
+  ashburn: string[];
+  fairfax: string[];
+  gainesville: string[];
+  leesburg: string[];
+  leesburgSatellite: string[];
+  reston: string[];
+  sterling: string[];
+  sully: string[];
+};
+
 type SettledPromise<T> =
   | {
       ok: true;
@@ -215,6 +235,7 @@ const normalizeSpace = (text: string): string =>
   text.replace(/[’]/g, "'").replace(/\s+/g, " ").trim();
 
 const uniqueTimes = (times: string[]): string[] => Array.from(new Set(times));
+const adamsCheckWebsiteTimes = (): string[] => ["check website"];
 
 const settlePromise = async <T>(
   promise: Promise<T>,
@@ -278,26 +299,103 @@ const extractAdamsJumaTimes = (
   return times;
 };
 
-const loadAdamsJumaTimes = async () => {
-  const $ = await util.load(ADAMS_JUMUAH_URL);
-  const bodyText = normalizeSpace($("body").text());
+const fallbackAdamsJumaTimes = (): AdamsJumaTimes => ({
+  ashburn: adamsCheckWebsiteTimes(),
+  fairfax: adamsCheckWebsiteTimes(),
+  gainesville: adamsCheckWebsiteTimes(),
+  leesburg: adamsCheckWebsiteTimes(),
+  leesburgSatellite: adamsCheckWebsiteTimes(),
+  reston: adamsCheckWebsiteTimes(),
+  sterling: adamsCheckWebsiteTimes(),
+  sully: adamsCheckWebsiteTimes(),
+});
+
+const extractAdamsJumaTimesFromSources = (
+  texts: string[],
+): AdamsJumaTimes | null => {
+  const extractFromSources = (
+    label: (typeof ADAMS_JUMUAH_LABELS)[number],
+  ): string[] | null => {
+    for (const text of texts) {
+      if (text.includes(label)) {
+        try {
+          return extractAdamsJumaTimes(text, label);
+        } catch {}
+      }
+    }
+
+    return null;
+  };
+
+  const ashburn = extractFromSources("Ashburn Jumu'ah");
+  const fairfax = extractFromSources("Fairfax Jumu'ah");
+  const gainesville = extractFromSources("Gainesville Satellite Jumu'ah");
+  const leesburg = extractFromSources("Leesburg Jumu'ah");
+  const leesburgSatellite = extractFromSources("Leesburg Satellite Jumu'ah");
+  const reston = extractFromSources("Reston Jumu'ah");
+  const sterling = extractFromSources("Sterling Jumu'ah");
+  const sully = extractFromSources("Sully Jumu'ah");
+  if (
+    !ashburn ||
+    !fairfax ||
+    !gainesville ||
+    !leesburg ||
+    !leesburgSatellite ||
+    !reston ||
+    !sterling ||
+    !sully
+  ) {
+    return null;
+  }
 
   return {
-    ashburn: extractAdamsJumaTimes(bodyText, "Ashburn Jumu'ah"),
-    fairfax: extractAdamsJumaTimes(bodyText, "Fairfax Jumu'ah"),
-    gainesville: extractAdamsJumaTimes(
-      bodyText,
-      "Gainesville Satellite Jumu'ah",
-    ),
-    leesburg: extractAdamsJumaTimes(bodyText, "Leesburg Jumu'ah"),
-    leesburgSatellite: extractAdamsJumaTimes(
-      bodyText,
-      "Leesburg Satellite Jumu'ah",
-    ),
-    reston: extractAdamsJumaTimes(bodyText, "Reston Jumu'ah"),
-    sterling: extractAdamsJumaTimes(bodyText, "Sterling Jumu'ah"),
-    sully: extractAdamsJumaTimes(bodyText, "Sully Jumu'ah"),
+    ashburn,
+    fairfax,
+    gainesville,
+    leesburg,
+    leesburgSatellite,
+    reston,
+    sterling,
+    sully,
   };
+};
+
+const loadAdamsJumaTimes = async (): Promise<AdamsJumaTimes> => {
+  const [$, apiPages] = await Promise.all([
+    util.load(ADAMS_JUMUAH_URL),
+    util.loadJson<AdamsWordPressPage[]>(ADAMS_JUMUAH_API_URL),
+  ]);
+  const renderedContent = Array.isArray(apiPages)
+    ? apiPages.find((entry) => typeof entry.content?.rendered === "string")
+        ?.content?.rendered
+    : "";
+  const renderedContentText =
+    typeof renderedContent === "string"
+      ? normalizeSpace(cheerio.load(renderedContent).text())
+      : "";
+  const sourceTexts = [
+    normalizeSpace($("body").text()),
+    renderedContentText,
+    normalizeSpace($('meta[name="description"]').attr("content") ?? ""),
+    normalizeSpace($('meta[property="og:description"]').attr("content") ?? ""),
+    normalizeSpace($('meta[name="twitter:description"]').attr("content") ?? ""),
+  ].filter((text) => text.length > 0);
+
+  const parsed = extractAdamsJumaTimesFromSources(sourceTexts);
+  if (parsed) {
+    return parsed;
+  }
+
+  if (
+    typeof renderedContent === "string" &&
+    /wp-content\/uploads\/\d{4}\/\d{2}\/[^"' >]*(jummah|jumuah|jum['’]?ah)[^"' >]*\.(png|jpe?g)/i.test(
+      renderedContent,
+    )
+  ) {
+    return fallbackAdamsJumaTimes();
+  }
+
+  throw new Error("missing ADAMS Jumu'ah schedule");
 };
 
 const loadTysonsJumaTimes = async (): Promise<string[]> => {

--- a/src/masjidbox.ts
+++ b/src/masjidbox.ts
@@ -1,3 +1,4 @@
+import type * as cheerio from "cheerio";
 import type { CrawlerIds, CrawlerRun } from "./types";
 import * as util from "./util";
 
@@ -32,7 +33,18 @@ type MasjidBoxWidgetResponse = {
   timetable?: unknown;
 };
 
-const widgetJumuahValues = (day: MasjidBoxWidgetDay): unknown[] => {
+type MasjidBoxLandingState = {
+  masjidbox?: {
+    masjidboxAthany?: {
+      settings?: {
+        timezone?: unknown;
+      };
+      timetable?: unknown;
+    };
+  };
+};
+
+const masjidBoxJumuahValues = (day: MasjidBoxWidgetDay): unknown[] => {
   if (Array.isArray(day.jumuah)) {
     return day.jumuah;
   }
@@ -41,6 +53,78 @@ const widgetJumuahValues = (day: MasjidBoxWidgetDay): unknown[] => {
   }
 
   return [];
+};
+
+const currentMasjidBoxDay = (
+  timetable: MasjidBoxWidgetDay[],
+  timeZoneId: string,
+): MasjidBoxWidgetDay | undefined => {
+  if (timetable.length === 0) {
+    return undefined;
+  }
+
+  const today = util.strftime("%F", { timeZoneId });
+  return (
+    timetable.find(
+      (entry) => typeof entry.date === "string" && entry.date.startsWith(today),
+    ) ?? timetable[0]
+  );
+};
+
+const currentMasjidBoxJumuahDay = (
+  timetable: MasjidBoxWidgetDay[],
+  currentDay: MasjidBoxWidgetDay | undefined,
+): MasjidBoxWidgetDay | undefined => {
+  if (!currentDay) {
+    return timetable.find((entry) => masjidBoxJumuahValues(entry).length > 0);
+  }
+
+  const currentDayIndex = Math.max(0, timetable.indexOf(currentDay));
+  return (
+    timetable
+      .slice(currentDayIndex)
+      .find((entry) => masjidBoxJumuahValues(entry).length > 0) ??
+    timetable.find((entry) => masjidBoxJumuahValues(entry).length > 0)
+  );
+};
+
+const loadMasjidBoxLandingState = (
+  $: cheerio.CheerioAPI,
+): { timeZoneId: string; timetable: MasjidBoxWidgetDay[] } | null => {
+  const reduxStateText =
+    $("script")
+      .toArray()
+      .map((script) => $(script).text())
+      .find((text) => text.includes("window.REDUX_STATE")) ?? "";
+  const match = reduxStateText.match(/window\.REDUX_STATE\s*=\s*'([^']+)'/);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  try {
+    const decoded = decodeURIComponent(
+      match[1].replace(/%(?![0-9a-f]{2})/gi, "%25"),
+    );
+    const payload = JSON.parse(decoded) as MasjidBoxLandingState;
+    const athany = payload.masjidbox?.masjidboxAthany;
+    const timeZoneId =
+      typeof athany?.settings?.timezone === "string"
+        ? athany.settings.timezone
+        : "";
+    const timetable = Array.isArray(athany?.timetable)
+      ? (athany.timetable as MasjidBoxWidgetDay[])
+      : [];
+    if (!timeZoneId || timetable.length === 0) {
+      return null;
+    }
+
+    return {
+      timeZoneId,
+      timetable,
+    };
+  } catch {
+    return null;
+  }
 };
 
 export const parseMasjidBoxTime = (value: string): string => {
@@ -69,6 +153,63 @@ export const loadMasjidBoxTimes = async (
   url: string,
 ): Promise<{ iqamaTimes: string[]; jumaTimes: string[] }> => {
   const $ = await util.load(url);
+
+  const landingState = loadMasjidBoxLandingState($);
+  if (landingState) {
+    const currentDay = currentMasjidBoxDay(
+      landingState.timetable,
+      landingState.timeZoneId,
+    );
+    const jumuahDay = currentMasjidBoxJumuahDay(
+      landingState.timetable,
+      currentDay,
+    );
+    const iqamah = currentDay?.iqamah;
+    const iqamaTimes = uniqueTimes([
+      util.normalizeIsoClock(
+        iqamah?.fajr,
+        landingState.timeZoneId,
+        parseMasjidBoxTime,
+      ),
+      util.normalizeIsoClock(
+        iqamah?.dhuhr,
+        landingState.timeZoneId,
+        parseMasjidBoxTime,
+      ),
+      util.normalizeIsoClock(
+        iqamah?.asr,
+        landingState.timeZoneId,
+        parseMasjidBoxTime,
+      ),
+      util.normalizeIsoClock(
+        iqamah?.maghrib,
+        landingState.timeZoneId,
+        parseMasjidBoxTime,
+      ),
+      util.normalizeIsoClock(
+        iqamah?.isha,
+        landingState.timeZoneId,
+        parseMasjidBoxTime,
+      ),
+    ]);
+    const jumaTimes = uniqueTimes(
+      masjidBoxJumuahValues(jumuahDay ?? currentDay ?? {})
+        .map((value) =>
+          util.normalizeIsoClock(
+            value,
+            landingState.timeZoneId,
+            parseMasjidBoxTime,
+          ),
+        )
+        .filter(Boolean),
+    );
+    if (iqamaTimes.length >= 5 && jumaTimes.length > 0) {
+      return {
+        iqamaTimes: iqamaTimes.slice(0, 5),
+        jumaTimes: jumaTimes.slice(0, 3),
+      };
+    }
+  }
 
   const iqamaTimes = uniqueTimes(
     util.mapToText($, "div.iqamah div.time").map(parseMasjidBoxTime),
@@ -122,11 +263,7 @@ export const loadMasjidBoxWidgetTimes = async (
     throw new Error("failed to load masjidbox widget timetable");
   }
 
-  const today = util.strftime("%F", { timeZoneId });
-  const currentDay =
-    timetable.find(
-      (entry) => typeof entry.date === "string" && entry.date.startsWith(today),
-    ) ?? timetable[0];
+  const currentDay = currentMasjidBoxDay(timetable, timeZoneId);
   if (!currentDay) {
     throw new Error("missing current masjidbox widget prayer day");
   }
@@ -143,13 +280,8 @@ export const loadMasjidBoxWidgetTimes = async (
     throw new Error("failed to parse masjidbox widget iqama timings");
   }
 
-  const currentDayIndex = Math.max(0, timetable.indexOf(currentDay));
-  const jumuahDay =
-    timetable
-      .slice(currentDayIndex)
-      .find((entry) => widgetJumuahValues(entry).length > 0) ??
-    timetable.find((entry) => widgetJumuahValues(entry).length > 0);
-  const jumuah = jumuahDay ? widgetJumuahValues(jumuahDay) : [];
+  const jumuahDay = currentMasjidBoxJumuahDay(timetable, currentDay);
+  const jumuah = jumuahDay ? masjidBoxJumuahValues(jumuahDay) : [];
   const jumaTimes = uniqueTimes(
     jumuah.map((value) =>
       util.normalizeIsoClock(value, timeZoneId, parseMasjidBoxTime),

--- a/src/ppt.ts
+++ b/src/ppt.ts
@@ -31,3 +31,73 @@ export const loadFrameAfterGoto = async (
 
   return frame;
 };
+
+const firstMosquePrayerTimesClock = (text: string): string => {
+  const value = text.match(/\d{1,2}:\d{2}/)?.[0] ?? "";
+  return util.normalizeLooseClock(value);
+};
+
+export const loadMosquePrayerTimesTable = async (
+  page: Page,
+): Promise<{ iqamaTimes: string[]; jumaTimes: string[] }> => {
+  const rows = await page.$$eval(".timetable-verticle tr", (tableRows) =>
+    tableRows.map((row) =>
+      Array.from(
+        (
+          row as { querySelectorAll(selector: string): unknown[] }
+        ).querySelectorAll("td, th"),
+      ).map(
+        (cell) =>
+          (cell as { textContent: string | null }).textContent
+            ?.replace(/\s+/g, " ")
+            .trim() ?? "",
+      ),
+    ),
+  );
+  if (rows.length === 0) {
+    throw new Error("missing mosqueprayertimes timetable rows");
+  }
+
+  const prayerTimes = new Map<string, string>();
+  let jumaTimes: string[] = [];
+  for (const cells of rows) {
+    const label = (cells[0] ?? "").replace(/\s+/g, " ").trim();
+    const prayerKey = util.getStandardPrayerKey(label);
+    if (prayerKey) {
+      const iqamaTime = firstMosquePrayerTimesClock(cells[2] ?? "");
+      if (iqamaTime) {
+        prayerTimes.set(prayerKey, iqamaTime);
+      }
+      continue;
+    }
+
+    if (/jum['’]?ah/i.test(label)) {
+      const jumaTime = firstMosquePrayerTimesClock(cells[1] ?? cells[2] ?? "");
+      if (jumaTime) {
+        jumaTimes = [jumaTime];
+      }
+    }
+  }
+
+  if (!prayerTimes.get("zuhr") && jumaTimes[0]) {
+    prayerTimes.set("zuhr", jumaTimes[0]);
+  }
+
+  return {
+    iqamaTimes: util.requireStandardPrayerTimes(
+      prayerTimes,
+      "failed to parse mosqueprayertimes iqama times",
+    ),
+    jumaTimes,
+  };
+};
+
+export const createMosquePrayerTimesRun = (ids: CrawlerIds): CrawlerRun => {
+  return createPuppeteerRun(ids, async (page) => {
+    await page.goto(ids[0].url ?? "", { waitUntil: "networkidle0" });
+
+    const { iqamaTimes, jumaTimes } = await loadMosquePrayerTimesTable(page);
+    util.setIqamaTimes(ids[0], iqamaTimes);
+    util.setJumaTimes(ids[0], jumaTimes);
+  });
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1145,6 +1145,25 @@ export const normalizeLooseClock = (value: unknown): string => {
   return extractTimeAmPm(trimmed) || extractTime(trimmed) || trimmed;
 };
 
+export const normalize24HourClock = (
+  value: string | null | undefined,
+): string => {
+  const match = value?.trim().match(/^(\d{1,2}):(\d{2})(?::\d{2})?$/);
+  if (!match?.[1] || !match[2]) {
+    return "";
+  }
+
+  const hours24 = Number.parseInt(match[1], 10);
+  const minutes = match[2];
+  if (!Number.isFinite(hours24)) {
+    return "";
+  }
+
+  const suffix = hours24 >= 12 ? "PM" : "AM";
+  const hours12 = ((hours24 + 11) % 12) + 1;
+  return `${hours12}:${minutes} ${suffix}`;
+};
+
 export const normalizeIsoClock = (
   value: unknown,
   timeZoneId: string,


### PR DESCRIPTION
## Summary
- harden shared MasjidBox and mosqueprayertimes parsing so the OH and NY crawlers from the remote sqlite snapshot stop mis-parsing Friday data
- update the affected crawlers to use current authoritative sources or fail closed with check website when the live site only exposes the current schedule in Eid/image-only content
- switch Al-Amaan to the current PDF schedule, keep Salahadeen's live Jumu'ah slots while failing closed on missing daily MadinaApps iqamah fields, and avoid stale Utah/ISNF Buffalo Ramadan fallbacks on Eid-only PDFs

## Validation
- `bun run . --save CA/ON/mosque-aisha-naigara US/CA/masjid-al-huda-union-city US/CA/sacramento-area-league-muslims-sacramento US/MN/al-amaan-center-minnetonka US/NY/cheektowaga-islamic-cultural-center-cheektowaga US/NY/isnf-masjid-an-noor-amherst-getzville US/NY/masjid-al-salam-msjd-lslm-buffalo US/OH/islamic-association-of-cincinnati-cincinnati US/OH/noor-islamic-cultural-center-dublin US/TN/salahadeen-center-nashville US/UT/islamic-society-of-greater-salt-lake US/VA/adams-center`
- `bun run . --save --force US/UT/islamic-society-of-greater-salt-lake US/VA/adams-center`
- `bun run . --save US/MN/al-amaan-center-minnetonka US/TN/salahadeen-center-nashville US/NY/cheektowaga-islamic-cultural-center-cheektowaga US/NY/masjid-al-salam-msjd-lslm-buffalo US/TX/barakat-ul-quran-irving`
- `bun run --parallel typecheck lint cpd test`

## Remaining blockers
- `CA/BC/jamia-riyadhul-jannah-maple-ridge-maple-ridge`, `US/FL/davenport-muslim-prayer-davenport`, and `US/TX/dar-alhuda-inc-msjd-hurst` are still publishing invalid/stale live times, so they remain outside this patch
