### PR TITLE
Fix non-transient crawler regressions from praytime.sqlite

### DIFF
--- a/src/crawlers/US/CO/masjid-abu-bakr-msjd-denver.ts
+++ b/src/crawlers/US/CO/masjid-abu-bakr-msjd-denver.ts
@@ -1,5 +1,6 @@
-import { createDptTimetableRun } from "../../../dpt";
+import { loadDptTimetableTimes } from "../../../dpt";
 import type { CrawlerModule } from "../../../types";
+import * as util from "../../../util";
 
 const ids: CrawlerModule["ids"] = [
   {
@@ -18,7 +19,21 @@ const ids: CrawlerModule["ids"] = [
 export const crawler: CrawlerModule = {
   name: "US/CO/masjid-abu-bakr-msjd-denver",
   ids,
-  run: createDptTimetableRun(ids, ids[0].url, {
-    errorContext: "Colorado Muslim Society timetable",
-  }),
+  run: async () => {
+    const { iqamaTimes, jumaTimes } = await loadDptTimetableTimes(
+      ids[0].url ?? "",
+      {
+        errorContext: "Colorado Muslim Society timetable",
+      },
+    );
+
+    if (util.isJumaToday(ids[0])) {
+      iqamaTimes[1] = "Juma";
+    }
+
+    util.setIqamaTimes(ids[0], iqamaTimes);
+    util.setJumaTimes(ids[0], jumaTimes.slice(0, 3));
+
+    return ids;
+  },
 };

--- a/src/crawlers/US/NC/apex-mosque-apex.ts
+++ b/src/crawlers/US/NC/apex-mosque-apex.ts
@@ -1,5 +1,5 @@
-import { createSelectorRun } from "../../../selectors";
 import type { CrawlerModule } from "../../../types";
+import * as util from "../../../util";
 
 const ids: CrawlerModule["ids"] = [
   {
@@ -18,8 +18,27 @@ const ids: CrawlerModule["ids"] = [
 export const crawler: CrawlerModule = {
   name: "US/NC/apex-mosque-apex",
   ids,
-  run: createSelectorRun(ids, {
-    iqama: { limit: 5, selector: ".jamah" },
-    juma: { parser: "extractTimeAmPm", selector: "span.dsJumuah" },
-  }),
+  run: async () => {
+    const $ = await util.load(ids[0].url ?? "");
+    const iqamaTimes = util.mapToText($, ".dptTimetable td.jamah").slice(0, 5);
+    const jumaTimes = util
+      .mapToText($, ".dptTimetable .dsJumuah")
+      .map(util.extractTimeAmPm)
+      .filter((value): value is string => Boolean(value));
+
+    if (iqamaTimes.length < 5) {
+      throw new Error(
+        `failed to parse selector iqama times from ${ids[0].url}`,
+      );
+    }
+
+    if (util.isJumaToday(ids[0])) {
+      iqamaTimes[1] = "Juma";
+    }
+
+    util.setIqamaTimes(ids[0], iqamaTimes);
+    util.setJumaTimes(ids[0], jumaTimes);
+
+    return ids;
+  },
 };

--- a/src/crawlers/US/NY/masjid-at-taqwa.ts
+++ b/src/crawlers/US/NY/masjid-at-taqwa.ts
@@ -16,29 +16,68 @@ const ids: CrawlerModule["ids"] = [
   },
 ];
 type MasjidKitPageData = {
+  jummahSchedules?: MasjidKitJummahSchedule[];
+  jummahTimes?: MasjidKitJummahSchedule[];
+  prayerTimes?: MasjidKitPrayerSchedule[];
   props?: {
     pageProps?: {
       siteBuilderDataJSON?: {
         json?: {
           data?: {
-            jummahSchedules?: Array<{
-              date?: string;
-              khutbahs?: Array<{
-                prayerTime?: string;
-              }>;
-            }>;
-            prayerTimesSchedules?: Array<{
-              date?: string;
-              fajr?: { commences?: string };
-              dhuhr?: { commences?: string };
-              asr?: { commences?: string };
-              maghrib?: { commences?: string };
-              isha?: { commences?: string };
-            }>;
+            jummahSchedules?: MasjidKitJummahSchedule[];
+            prayerTimesSchedules?: MasjidKitPrayerSchedule[];
           };
         };
       };
     };
+  };
+};
+
+type MasjidKitJummahSchedule = {
+  date?: string;
+  khutbahs?: Array<{
+    prayerTime?: string;
+  }>;
+};
+
+type MasjidKitPrayerSchedule = {
+  date?: string;
+  fajr?: { commences?: string };
+  dhuhr?: { commences?: string };
+  asr?: { commences?: string };
+  maghrib?: { commences?: string };
+  isha?: { commences?: string };
+};
+
+const pageDataSchedules = (
+  pageData: MasjidKitPageData,
+): {
+  jummahSchedules: NonNullable<MasjidKitPageData["jummahSchedules"]>;
+  prayerTimes: NonNullable<MasjidKitPageData["prayerTimes"]>;
+} => {
+  const directPrayerTimes = pageData.prayerTimes;
+  const directJummahSchedules =
+    pageData.jummahTimes ?? pageData.jummahSchedules;
+  if (
+    Array.isArray(directPrayerTimes) &&
+    Array.isArray(directJummahSchedules)
+  ) {
+    return {
+      jummahSchedules: directJummahSchedules,
+      prayerTimes: directPrayerTimes,
+    };
+  }
+
+  const nestedData = pageData.props?.pageProps?.siteBuilderDataJSON?.json?.data;
+  const prayerTimes = nestedData?.prayerTimesSchedules;
+  const jummahSchedules = nestedData?.jummahSchedules;
+  if (!Array.isArray(prayerTimes) || !Array.isArray(jummahSchedules)) {
+    throw new Error("missing MasjidKit schedules");
+  }
+
+  return {
+    jummahSchedules,
+    prayerTimes,
   };
 };
 
@@ -60,21 +99,16 @@ const formatMasjidKitTime = (
 
 const run = async () => {
   const $ = await util.load(ids[0].url ?? "");
-  const nextDataJson = $("#__NEXT_DATA__").html();
-  if (!nextDataJson) {
-    throw new Error("missing MasjidKit next data");
+  const dataJson = $("#__DATA__").html() ?? $("#__NEXT_DATA__").html();
+  if (!dataJson) {
+    throw new Error("missing MasjidKit page data");
   }
 
-  const pageData = JSON.parse(nextDataJson) as MasjidKitPageData;
-  const schedules =
-    pageData.props?.pageProps?.siteBuilderDataJSON?.json?.data
-      ?.prayerTimesSchedules;
-  if (!Array.isArray(schedules)) {
-    throw new Error("missing MasjidKit prayer schedules");
-  }
+  const pageData = JSON.parse(dataJson) as MasjidKitPageData;
+  const { prayerTimes, jummahSchedules } = pageDataSchedules(pageData);
 
   const today = util.strftime("%Y-%m-%d", ids[0]);
-  const todaySchedule = schedules.find((schedule) => schedule.date === today);
+  const todaySchedule = prayerTimes.find((schedule) => schedule.date === today);
   if (!todaySchedule) {
     throw new Error(`missing MasjidKit prayer schedule for ${today}`);
   }
@@ -86,12 +120,6 @@ const run = async () => {
     formatMasjidKitTime(todaySchedule.maghrib?.commences, ids[0].timeZoneId),
     formatMasjidKitTime(todaySchedule.isha?.commences, ids[0].timeZoneId),
   ]);
-
-  const jummahSchedules =
-    pageData.props?.pageProps?.siteBuilderDataJSON?.json?.data?.jummahSchedules;
-  if (!Array.isArray(jummahSchedules)) {
-    throw new Error("missing MasjidKit jummah schedules");
-  }
 
   const nextJummah = jummahSchedules.find(
     (schedule) => typeof schedule.date === "string" && schedule.date >= today,

--- a/src/crawlers/US/WA/sammamish-mosque.ts
+++ b/src/crawlers/US/WA/sammamish-mosque.ts
@@ -1,5 +1,5 @@
-import { createMuslimFeedRun } from "../../../muslimfeed";
 import type { CrawlerModule } from "../../../types";
+import * as util from "../../../util";
 
 const ids: CrawlerModule["ids"] = [
   {
@@ -18,5 +18,64 @@ const ids: CrawlerModule["ids"] = [
 export const crawler: CrawlerModule = {
   name: "US/WA/sammamish-mosque",
   ids,
-  run: createMuslimFeedRun(ids, "2110"),
+  run: async () => {
+    const $ = await util.load(ids[0].url ?? "");
+    const localDate = new Intl.DateTimeFormat("en-US", {
+      weekday: "long",
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+      timeZone: ids[0].timeZoneId,
+    }).format(new Date());
+    const todayTable = $(".table_new.mySlides_new")
+      .toArray()
+      .find((element) =>
+        $(element)
+          .find(".date_section #gregorian-date_new")
+          .toArray()
+          .some((node) =>
+            util.normalizeSpace($(node).text()).includes(localDate),
+          ),
+      );
+
+    if (!todayTable) {
+      throw new Error(`missing Sammamish prayer table for ${localDate}`);
+    }
+
+    const prayerRows = $(todayTable).find("tr").toArray();
+    const prayerTimes = new Map<util.StandardPrayerKey, string>();
+    for (const row of prayerRows) {
+      const label = util.normalizeSpace(
+        $(row).find("td.prayer-name, th.prayerName").first().text(),
+      );
+      const prayerKey = util.getStandardPrayerKey(label);
+      if (!prayerKey || prayerTimes.has(prayerKey)) {
+        continue;
+      }
+
+      const iqama = util.extractTimeAmPm(
+        $(row).find("td.iqama-time, td.jamah").last().text(),
+      );
+      if (iqama) {
+        prayerTimes.set(prayerKey, iqama);
+      }
+    }
+
+    const jumaTimes = $(todayTable)
+      .find(".jamu_sec_layout2 h1")
+      .toArray()
+      .map((node) => util.extractTimeAmPm($(node).text()))
+      .filter((value): value is string => Boolean(value));
+
+    util.setIqamaTimes(
+      ids[0],
+      util.requireStandardPrayerTimes(
+        prayerTimes,
+        "failed to parse Sammamish Mosque prayer times",
+      ),
+    );
+    util.setJumaTimes(ids[0], jumaTimes);
+
+    return ids;
+  },
 };

--- a/src/mawaqit.ts
+++ b/src/mawaqit.ts
@@ -135,9 +135,19 @@ const extractPrayerTimes = (
     throw new Error(`failed to parse mawaqit iqamah time: ${entry}`);
   });
 
+  const seenJumaTimes = new Set<string>();
   const jumaTimes = [payload.jumua, payload.jumua2, payload.jumua3]
     .map(normalizeClock)
-    .filter((time): time is string => time.length > 0);
+    .filter((time): time is string => time.length > 0)
+    .filter((time) => {
+      const key = time.replace(/\s+/g, "").toLowerCase();
+      if (!key || seenJumaTimes.has(key)) {
+        return false;
+      }
+
+      seenJumaTimes.add(key);
+      return true;
+    });
   if (jumaTimes.length === 0) {
     throw new Error("failed to parse mawaqit juma times");
   }


### PR DESCRIPTION
## Summary
- dedupe duplicate Mawaqit Jumu'ah slots so identical times do not create phantom extra prayers
- support the new `#__DATA__` MasjidKit payload shape in `US/NY/masjid-at-taqwa`
- handle Friday DPT timetable pages that replace Zuhr with Jumu'ah in Denver and Apex
- replace the dead Sammamish MuslimFeed dependency with direct site parsing of the rendered daily table

## Verification
- `bun run . US/NY/al-iman-mosque-queens`
- `bun run . US/NY/masjid-at-taqwa US/CO/masjid-abu-bakr-msjd-denver US/NC/apex-mosque-apex US/WA/sammamish-mosque`
- `bun run . --save US/NY/masjid-at-taqwa US/CO/masjid-abu-bakr-msjd-denver US/NC/apex-mosque-apex US/WA/sammamish-mosque`
- `bun run . --save --force US/NY/al-iman-mosque-queens`
- `bun run --parallel typecheck lint cpd test`

## Notes
- `US/NY/al-iman-mosque-queens` needed `--force` because the source only exposes one distinct Jumu'ah slot now; `jumua` and `jumua2` are both `13:00` in the live Mawaqit payload.
- I also rechecked the other remaining non-transient failures from the remote `praytime.sqlite`. The unrepaired set are currently source-side issues such as dead MuslimFeed pages, empty MadinaApps payloads on the publisher's own site, or sites publishing obviously stale schedules that still fail validation.
